### PR TITLE
Quick path fix so the example will compile in Build

### DIFF
--- a/firmware/examples/integration-tests.cpp
+++ b/firmware/examples/integration-tests.cpp
@@ -24,7 +24,7 @@
 #include <memory>
 
 #include "flashee-eeprom/flashee-eeprom.h"
-#include "spark-unit.h"
+#include "flashee-eeprom/spark-unit.h"
 
 using namespace Flashee;
 


### PR DESCRIPTION
Hiya Mat! Caught a path problem that lead to a compile error while looking for Electron compat problems. Could ya accept this and reimport it?

Thanks!
