### PR TITLE
Fix wrong argument in FSDirList init

### DIFF
--- a/firmware/FlashIO.h
+++ b/firmware/FlashIO.h
@@ -154,7 +154,7 @@ class FSDirList {
         
 private:
     
-    FSDirList(FSDir& dir_) : dir(dir) {}
+    FSDirList(FSDir& dir_) : dir(dir_) {}
     
     bool next() {
         return f_readdir(&dir.dir, &fno)!=FR_OK || !*fno.fname;        


### PR DESCRIPTION
It seems that the wrong argument is used in the initializer list.