### PR TITLE
Also support PLATFORM_ID==3 for EepromFlashDevice

### DIFF
--- a/firmware/flashee-eeprom.h
+++ b/firmware/flashee-eeprom.h
@@ -549,7 +549,7 @@ public:
 #if defined(SPARK)
     #if PLATFORM_ID<3
             return createAddressErase();
-    #elif PLATFORM_ID==4 || PLATFORM_ID==6 || PLATFORM_ID==10
+    #elif PLATFORM_ID==3 || PLATFORM_ID==4 || PLATFORM_ID==6 || PLATFORM_ID==10
             return new EepromFlashDevice();
     #elif PLATFORM_ID==5 || PLATFORM_ID==7 || PLATFORM_ID==8
            // P1


### PR DESCRIPTION
PLATFORM_ID==3 is not included as allowed platform for EepromFlashDevice, but we're using it in BrewPi with a simulated EEPROM.
This code is used in BrewPi, can it be included upstream too?