### PR TITLE
More robust windows platform detection

### DIFF
--- a/firmware/integer.h
+++ b/firmware/integer.h
@@ -5,7 +5,7 @@
 #ifndef _FF_INTEGER
 #define _FF_INTEGER
 
-#ifdef _WIN32	/* FatFs development platform */
+#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32)	/* FatFs development platform */
 
 #include <windows.h>
 #include <tchar.h>


### PR DESCRIPTION
The #ifdef to detect whether on Windows wasn't working for me. This implementation tests multiple variations of the define to be more robust.